### PR TITLE
ゲストトップ画面

### DIFF
--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,3 +1,10 @@
 class TopsController < ApplicationController
-  def tops; end
+  def index
+    if user_signed_in?
+      # user_signed_in?: ログインしているかどうかを判定するdevise標準メソッド
+      render 'index'
+    else
+      render 'gest_index'
+    end
+  end
 end

--- a/app/controllers/users/application_controller.rb
+++ b/app/controllers/users/application_controller.rb
@@ -1,4 +1,0 @@
-class ApplicationController < ActionController::Base
-  add_flash_types :success, :danger
-  # フラッシュメッセージのkeyを追加（デフォルト: notice, alert）
-end

--- a/app/views/tops/gest_index.html.erb
+++ b/app/views/tops/gest_index.html.erb
@@ -1,0 +1,15 @@
+<div class="container mx-auto min-h-screen flex items-center justify-center">
+  <!--mx-auto:左右のマージンを自動調整、中央に配置, min-h-screen: 箱の高さを最低画面の高さと同じにする-->
+  <!--items-center: 垂直方向の中央揃え, justify-center: 水平方向の中央揃え-->
+  <div class="flex flex-col items-center gap-8">
+    <!--flex-col: 縦並びにする, items-center: 水平方向の中央揃え-->
+    <!--2x2の形にする-->
+    <div class="flex justify-center gap-8">
+      <div class="flex flex-col items-center shadow-lg rounded-lg p-4 bg-white border-2 object-cover border-gray-200">
+        <%= link_to image_tag("resipe_book.png", class: "w-40 h-40 object-cover"), "#" %>
+        <p class="mt-2 text-center font-semibold">レシピ一覧</p>
+      </div>
+    </div>
+    <%= link_to "ログイン", login_path %>
+  </div>
+</div>


### PR DESCRIPTION
## **実装内容**
- [x] ゲストトップ画面を表示
- [x] ログイン画面に飛ぶことができる
- [x] レシピ一覧のみを表示する

## **実装コード**
tops_controller.rb
```rb
class TopsController < ApplicationController
  def index
    if user_signed_in?
      render 'index'
    else
      render 'gest_index'
    end
  end
end
```  
---
tops/gest_index.html.erb
```erb
<div class="container mx-auto min-h-screen flex items-center justify-center">
  <!--mx-auto:左右のマージンを自動調整、中央に配置, min-h-screen: 箱の高さを最低画面の高さと同じにする-->
  <!--items-center: 垂直方向の中央揃え, justify-center: 水平方向の中央揃え-->
  <div class="flex flex-col items-center gap-8">
    <!--flex-col: 縦並びにする, items-center: 水平方向の中央揃え-->
    <!--2x2の形にする-->
    <div class="flex justify-center gap-8">
      <div class="flex flex-col items-center shadow-lg rounded-lg p-4 bg-white border-2 object-cover border-gray-200">
        <%= link_to image_tag("resipe_book.png", class: "w-40 h-40 object-cover"), "#" %>
        <p class="mt-2 text-center font-semibold">レシピ一覧</p>
      </div>
    </div>
    <%= link_to "ログイン", login_path %>
  </div>
</div>
```