### PR TITLE
ログインフォームデザイン修正

### DIFF
--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,40 +1,44 @@
-<!--ログインフォーム-->
-<div class="container">
-  <%= form_with url: login_path, scope: :session, local: true do |f| %>
-    <!--scope: :session : -->
+<div class="container mx-auto max-w-md mt-10">
+  <!--
+    mx-auto :左右のマージンを自動調節し、中央に配置
+    max-w-md :最大幅を指定し、画面幅がmd以上の場合は中央に配置
+  -->
+  <h2 class="text-2xl font-bold mb-6 text-center"><%= t('users.sessions.new.login') %></h2>
+
+  <%= form_with url: login_path, scope: :session, local: true, class: "space-y-4" do |f| %>
+    <!--space-y-4 :フォーム内の要素間に垂直方向の余白を追加-->
     <div class="input input-bordered flex items-center gap-2">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 16 16"
-        fill="currentColor"
-        class="h-4 w-4 opacity-70">
-        <path
-          d="M2.5 3A1.5 1.5 0 0 0 1 4.5v.793c.026.009.051.02.076.032L7.674 8.51c.206.1.446.1.652 0l6.598-3.185A.755.755 0 0 1 15 5.293V4.5A1.5 1.5 0 0 0 13.5 3h-11Z" />
-        <path
-          d="M15 6.954 8.978 9.86a2.25 2.25 0 0 1-1.956 0L1 6.954V11.5A1.5 1.5 0 0 0 2.5 13h11a1.5 1.5 0 0 0 1.5-1.5V6.954Z" />
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
+        <path d="M2.5 3A1.5 1.5 0 0 0 1 4.5v.793c.026.009.051.02.076.032L7.674 8.51c.206.1.446.1.652 0l6.598-3.185A.755.755 0 0 1 15 5.293V4.5A1.5 1.5 0 0 0 13.5 3h-11Z" />
+        <path d="M15 6.954 8.978 9.86a2.25 2.25 0 0 1-1.956 0L1 6.954V11.5A1.5 1.5 0 0 0 2.5 13h11a1.5 1.5 0 0 0 1.5-1.5V6.954Z" />
       </svg>
-      <%= f.email_field :email, class: "grow", placeholder: "Email" %>
-      <!--<input type="text" class="grow" placeholder="Email" />-->
+      <%= f.email_field :email, class: "grow", placeholder: t('users.sessions.new.email_placeholder') %>
     </div>
 
     <div class="input input-bordered flex items-center gap-2">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 16 16"
-        fill="currentColor"
-        class="h-4 w-4 opacity-70">
-        <path
-          fill-rule="evenodd"
-          d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z"
-          clip-rule="evenodd" />
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
+        <path fill-rule="evenodd" d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z" clip-rule="evenodd" />
       </svg>
-      <%= f.password_field :password, class: "grow", placeholder: "password" %>
-      <!--<input type="password" class="grow" value="password" />-->
+      <%= f.password_field :password, class: "grow", placeholder: t('users.sessions.new.password_placeholder') %>
     </div>
-    <%= f.submit t("users.sessions.new.sign_in"), class: "btn btn-secondary" %>
-      <!--<button class="btn btn-secondary">Secondary</button>-->
+
+    <div class="flex justify-center">
+      <!--ボタンを中央へ配置-->
+      <%= f.submit t('users.sessions.new.sign_in'), class: "btn btn-secondary px-6 py-2 rounded-md hover:bg-opacity-90 hover:shadow-md" %>
+        <!--
+          px-6 :左右のパディング設定
+          pyｰ2 :上下のパディング設定
+          rounded-md :角丸を設定
+          hover:bg-opacity-90 :hover時の背景色の透明度を90%に設定
+          hover:shadow-md :hover時の影を設定
+        -->
+    </div>
   <% end %>
-  <div class="text-center">
-    <%= link_to "会員登録がお済みでない方は、こちらへ", new_user_path %>
+
+  <div class="mt-6 text-center">
+    <p><%= t('users.sessions.new.no_account') %></p>
+      <!--アカウントをお持ちでない方はこちら-->
+    <%= link_to t('users.sessions.new.sign_up'), new_user_path, class: "text-secondary hover:underline" %>
+      <!--アカウント登録、hoverすると、下に線が現れる-->
   </div>
 </div>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -31,7 +31,11 @@ ja:
         sign_up: アカウント登録
     sessions:
       new:
-        sign_in: ログイン
+        sign_in: Login
+        email_placeholder: Email
+        password_placeholder: password
+        no_account: アカウントをお持ちでない方はこちら
+        sign_up: アカウント登録
       destroy:
         logout: ログアウト
   recipes:


### PR DESCRIPTION
## **実装した内容**
- [x] ログインフォームのデザイン修正
- [x] 日本語化の修正 

## **実装したコード**
### ログインフォームのデザイン修正
- users/sessions/new.htmlerb
```erb
<div class="container mx-auto max-w-md mt-10">
  <!--
    mx-auto :左右のマージンを自動調節し、中央に配置
    max-w-md :最大幅を指定し、画面幅がmd以上の場合は中央に配置
  -->
  <h2 class="text-2xl font-bold mb-6 text-center"><%= t('users.sessions.new.login') %></h2>

  <%= form_with url: login_path, scope: :session, local: true, class: "space-y-4" do |f| %>
    <!--space-y-4 :フォーム内の要素間に垂直方向の余白を追加-->
    <div class="input input-bordered flex items-center gap-2">
      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
        <path d="M2.5 3A1.5 1.5 0 0 0 1 4.5v.793c.026.009.051.02.076.032L7.674 8.51c.206.1.446.1.652 0l6.598-3.185A.755.755 0 0 1 15 5.293V4.5A1.5 1.5 0 0 0 13.5 3h-11Z" />
        <path d="M15 6.954 8.978 9.86a2.25 2.25 0 0 1-1.956 0L1 6.954V11.5A1.5 1.5 0 0 0 2.5 13h11a1.5 1.5 0 0 0 1.5-1.5V6.954Z" />
      </svg>
      <%= f.email_field :email, class: "grow", placeholder: t('users.sessions.new.email_placeholder') %>
    </div>

    <div class="input input-bordered flex items-center gap-2">
      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" class="h-4 w-4 opacity-70">
        <path fill-rule="evenodd" d="M14 6a4 4 0 0 1-4.899 3.899l-1.955 1.955a.5.5 0 0 1-.353.146H5v1.5a.5.5 0 0 1-.5.5h-2a.5.5 0 0 1-.5-.5v-2.293a.5.5 0 0 1 .146-.353l3.955-3.955A4 4 0 1 1 14 6Zm-4-2a.75.75 0 0 0 0 1.5.5.5 0 0 1 .5.5.75.75 0 0 0 1.5 0 2 2 0 0 0-2-2Z" clip-rule="evenodd" />
      </svg>
      <%= f.password_field :password, class: "grow", placeholder: t('users.sessions.new.password_placeholder') %>
    </div>

    <div class="flex justify-center">
      <!--ボタンを中央へ配置-->
      <%= f.submit t('users.sessions.new.sign_in'), class: "btn btn-secondary px-6 py-2 rounded-md hover:bg-opacity-90 hover:shadow-md" %>
        <!--
          px-6 :左右のパディング設定
          pyｰ2 :上下のパディング設定
          rounded-md :角丸を設定
          hover:bg-opacity-90 :hover時の背景色の透明度を90%に設定
          hover:shadow-md :hover時の影を設定
        -->
    </div>
  <% end %>

  <div class="mt-6 text-center">
    <p><%= t('users.sessions.new.no_account') %></p>
      <!--アカウントをお持ちでない方はこちら-->
    <%= link_to t('users.sessions.new.sign_up'), new_user_path, class: "text-secondary hover:underline" %>
      <!--アカウント登録、hoverすると、下に線が現れる-->
  </div>
</div>
```

### 日本語化の修正 
- ja.yml
```rb
        sign_in: Login
        email_placeholder: Email
        password_placeholder: password
        no_account: アカウントをお持ちでない方はこちら
        sign_up: アカウント登録
```