### PR TITLE
フッターとデザインの干渉修正

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,10 +9,20 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
-
-  <body>
+  <body class="flex flex-col min-h-screen">
+    <!--
+      flex-col :main,footerの順で縦方向に配置
+      min-h-screen  :画面の最低高さを画面いっぱいに設定
+                    :コンテンツが少なくても画面いっぱいに表示される
+    -->
     <%= render "shared/flash" %>
-    <%= yield %>
+    <main class="flex-grow pb-24">
+      <!--
+        flex-grow :bodyの中で余っている部分をmain要素が全て占有
+        pb-24 :下部に24pxのpaddingを設定することでデザインの被りを防ぐ
+      -->
+      <%= yield %>
+    </main>
     <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,5 @@
-<div class="btm-nav">
+<footer class="btm-nav fixed bottom-0 left-0 right-0 shadow-lg">
+  <!--フッターを画面下部に固定する-->
   <%= link_to root_path, class: "flex flex-col items-center justify-center p-2" do %>
     <%= image_tag('home.png', class: 'h-9 w-6', alt: 'Home icon') %>
     <span class="text-xs ">Home</span>
@@ -57,4 +58,4 @@
       <span class="text-xs ">ゲスト</span>
     <% end %>
   <% end %>
-</div>
+</footer>


### PR DESCRIPTION
## **実装した内容**
- [x] フッターとデザインの干渉を修正しました

## **実装したコード**
### フッターの固定
- _footer.html.erb
```erb
<footer class="btm-nav fixed bottom-0 left-0 right-0 shadow-lg">
  <!--フッターを画面下部に固定する-->
  ...(略)...
</footer>
```
---
### メイン要素下部にパディングを設定
- layouts/application.html.erb
```erb
<body class="flex flex-col min-h-screen">
    <!--
      flex-col :main,footerの順で縦方向に配置
      min-h-screen  :画面の最低高さを画面いっぱいに設定
                    :コンテンツが少なくても画面いっぱいに表示される
    -->
    <%= render "shared/flash" %>
    <main class="flex-grow pb-24">
      <!--
        flex-grow :bodyの中で余っている部分をmain要素が全て占有
        pb-24 :下部に24pxのpaddingを設定することでデザインの被りを防ぐ
      -->
      <%= yield %>
    </main>
    <%= render 'shared/footer' %>
  </body>
```
## 実際の画面
![スクリーンショット 2024-08-13 6 48 50](https://github.com/user-attachments/assets/0d04b131-63f0-447a-bbd2-37a11b912a20)

↓

![スクリーンショット 2024-08-13 6 36 22](https://github.com/user-attachments/assets/6ae500b1-3e9f-49dd-b479-09a9b5d38b2e)