### PR TITLE
アバターのキャッシュ保存先明記

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -46,4 +46,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   # def filename
   #   "something.jpg" if original_filename
   # end
+  def cache_dir
+    "#{Rails.root}/tmp/uploads"
+  end
 end


### PR DESCRIPTION
## **実装した内容**
- [x] avatar_uploader.rbにキャッシュの保存先を設定

## **実装したコード**
- 
```erb
def cache_dir
    "#{Rails.root}/tmp/uploads"
end
```