### PR TITLE
commentのカラム変更、FK記載変更

### DIFF
--- a/db/migrate/20240818115051_create_comments.rb
+++ b/db/migrate/20240818115051_create_comments.rb
@@ -1,9 +1,9 @@
 class CreateComments < ActiveRecord::Migration[7.1]
   def change
     create_table :comments do |t|
-      t.text :comment
-      t.integer :user_id
-      t.integer :recipe_id
+      t.text :body
+      t.references :user, foreign_key: true
+      t.references :recipe, foreign_key: true
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,11 +15,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_18_115051) do
   enable_extension "plpgsql"
 
   create_table "comments", force: :cascade do |t|
-    t.text "comment"
-    t.integer "user_id"
-    t.integer "recipe_id"
+    t.text "body"
+    t.bigint "user_id"
+    t.bigint "recipe_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_comments_on_recipe_id"
+    t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
   create_table "food_nutrients", force: :cascade do |t|
@@ -101,6 +103,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_18_115051) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "comments", "recipes"
+  add_foreign_key "comments", "users"
   add_foreign_key "food_nutrients", "foods"
   add_foreign_key "food_nutrients", "nutrients"
   add_foreign_key "recipe_foods", "foods"


### PR DESCRIPTION
## **実装した内容**
- [x] カラムの変更、FK記述方法変更しました

## **実装したコード**
### 20240818115051_create_comments.rb
```rb
  create_table "comments", force: :cascade do |t|
    t.text "body"
    t.bigint "user_id"
    t.bigint "recipe_id"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
    t.index ["recipe_id"], name: "index_comments_on_recipe_id"
    t.index ["user_id"], name: "index_comments_on_user_id"
  end
```
---

### schema.rb
```rb
  create_table "comments", force: :cascade do |t|
    t.text "body"
    t.bigint "user_id"
    t.bigint "recipe_id"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
    t.index ["recipe_id"], name: "index_comments_on_recipe_id"
    t.index ["user_id"], name: "index_comments_on_user_id"
  end

...(略)...

  add_foreign_key "comments", "recipes"
  add_foreign_key "comments", "users"
```
