### PR TITLE
ルーティング設定（コメント機能）

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,8 @@ Rails.application.routes.draw do
     member do
       delete 'remove_image'
     end
+    resources :comments, only: %i[create edit destroy], shallow: true
+      # shallow: trueでネストを浅くする(削除時、comment_idのみで削除可能)
   end
   get 'up' => 'rails/health#show', as: :rails_health_check
 end


### PR DESCRIPTION
## **実装した内容**
- [x] ルーティング設定

## **実装したコード**
### ルーティング設定
- routes.rb
```erb
resources :recipes do
    
...(略)...
    resources :comments, only: %i[create edit destroy], shallow: true
      # shallow: trueでネストを浅くする(削除時、comment_idのみで削除可能)
  end
```