### PR TITLE
コントローラー（コメント機能）

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,0 +1,21 @@
+class CommentsController < ApplicationController
+  def create
+    comment = current_user.comments.build(comment_params)
+    if comment.save
+      redirect_to comment.recipe, success: t('messages.save_success', model: Comment.model_name.human)
+    else
+      flash.now[:danger] = t('messages.save_failed', model: Comment.model_name.human)
+      render 'recipes/show', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def comment_params
+    params.require(:comment).permit(:body).merge(recipe_id: prams[:recipe_id])
+      # .merge(recipe_id: prams[:recipe_id]) :prams[:recipe_id]でURLのidを取得し、recipe_idとして使用
+      # ( 送られてきたコメント情報がどのレシピに紐づいているのかを判定するために使用 )
+      # .mergeを使用する理由: body(フォームデータ)とrecipe_id(URLパラメータ)を結合するため
+      # recipe_idを直接記述しない理由: 直接記述すると、フォームから送られてきたrecipe_idを許可してしまう可能性があるため
+  end
+end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -9,6 +9,17 @@ class CommentsController < ApplicationController
     end
   end
 
+  def edit
+    @comment = Comment.find(params[:id])
+      # @comment = viewで使用するため、インスタンス変数に代入
+  end
+
+  def destroy
+    comment = Comment.find(params[:id])
+    comment.destroy
+    redirect_to comment.recipe, success: t('messages.delete_success', model: Comment.model_name.human)
+  end
+
   private
 
   def comment_params

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -39,6 +39,9 @@ class RecipesController < ApplicationController
     # 特定のレシピを取得し、ユーザー情報も取得
   @nutrient_totals = @recipe.nutrient_totals
     #@recipe.nutrient_totalsを呼び出し、レシピ全体の栄養素合計を計算し、@nutrient_totalsに代入
+  @comment = Comment.new
+  @comments = @recipe.comments.includes(:user).order(created_at: :desc)
+    # 個々のレシピに対して、コメントしたコメント情報とコメントしたユーザー情報を取得
   end
 
   def edit; end


### PR DESCRIPTION
## **実装した内容**
- [x] コントローラー作成
- [x] recipes_controoler.rb / show にて情報を用意
- [x] comments_controller.rbにてコメント作成、編集、削除できるようにする 

## **実装したコード**
### recipes_controoler.rb / show にて情報を用意
- 
```rb
  @comment = Comment.new
  @comments = @recipe.comments.includes(:user).order(created_at: :desc)
    # 個々のレシピに対して、コメントしたコメント情報とコメントしたユーザー情報を取得
  end
```
---

###  comments_controller.rbにてコメント作成、編集、削除できる 
```rb
class CommentsController < ApplicationController
  def create
    comment = current_user.comments.build(comment_params)
    if comment.save
      redirect_to comment.recipe, success: t('messages.save_success', model: Comment.model_name.human)
    else
      flash.now[:danger] = t('messages.save_failed', model: Comment.model_name.human)
      render 'recipes/show', status: :unprocessable_entity
    end
  end

  def edit
    @comment = Comment.find(params[:id])
      # @comment = viewで使用するため、インスタンス変数に代入
  end

  def destroy
    comment = Comment.find(params[:id])
    comment.destroy
    redirect_to comment.recipe, success: t('messages.delete_success', model: Comment.model_name.human)
  end

  private

  def comment_params
    params.require(:comment).permit(:body).merge(recipe_id: prams[:recipe_id])
      # .merge(recipe_id: prams[:recipe_id]) :prams[:recipe_id]でURLのidを取得し、recipe_idとして使用
      # ( 送られてきたコメント情報がどのレシピに紐づいているのかを判定するために使用 )
      # .mergeを使用する理由: body(フォームデータ)とrecipe_id(URLパラメータ)を結合するため
      # recipe_idを直接記述しない理由: 直接記述すると、フォームから送られてきたrecipe_idを許可してしまう可能性があるため
  end
end
```