### PR TITLE
cook_laterモデル作成とアソシエーション設定

### DIFF
--- a/app/models/cook_later.rb
+++ b/app/models/cook_later.rb
@@ -1,0 +1,7 @@
+class Cooklater < ApplicationRecord
+  belong_to :user
+  belong_to :recipe
+
+  validates :user_id, uniqueness: { scope: :recipe_id }
+    # 1人のユーザーは1つのレシピに対して、1つのCooklaterしか作成できない
+end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -5,6 +5,7 @@ class Recipe < ApplicationRecord
   has_many :steps, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :yummies, dependent: :destroy
+  has_many :cook_laters, dependent: :destroy
   # dependent: :destroy : Recipeが削除されたら、そのRecipeに紐づく関連データも削除される
 
   accepts_nested_attributes_for :steps, allow_destroy: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,9 @@ class User < ApplicationRecord
   has_many :recipes, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :yummies, dependent: :destroy
+  has_many :cook_laters, through: :cook_laters, source: :recipe
+  # ユーザーはcook_latersを通じてrecipeテーブルへのアクセス権限を持つ
+  # user.cook_later_recipesで、ユーザーが「作りたいものリスト」へ追加したレシピを取得できる
   # dependent: :destroy : Userが削除されたら、そのUserに紐づくRecipe,comment,yummyも削除される
 
   # Include default devise modules. Others available are:
@@ -24,7 +27,7 @@ class User < ApplicationRecord
   #avatarカラムの画像アップロード
   mount_uploader :avatar, AvatarUploader
 
-  # ユーザーが行ったかを判定するメソッド
+  # ユーザーが行ったかを判定するメソッド(comment機能)
   def own?(object)
     id == object&.user_id
       # idがobjectのuser_idと一致するかを判定する

--- a/db/migrate/20240829104227_create_cook_laters.rb
+++ b/db/migrate/20240829104227_create_cook_laters.rb
@@ -1,0 +1,12 @@
+class CreateCookLaters < ActiveRecord::Migration[7.1]
+  def change
+    create_table :cook_laters do |t|
+      t.references :user, foreign_key: true
+      t.references :recipe, foreign_key: true
+
+      t.timestamps
+      add_index :cook_laters, [:user_id, :recipe_id], unique: true
+        # 同じuser_idとrecipe_idの組み合わせが重複しないようにする
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_28_123204) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_29_104227) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -22,6 +22,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_28_123204) do
     t.datetime "updated_at", null: false
     t.index ["recipe_id"], name: "index_comments_on_recipe_id"
     t.index ["user_id"], name: "index_comments_on_user_id"
+  end
+
+  create_table "cook_laters", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "recipe_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipe_id"], name: "index_cook_laters_on_recipe_id"
+    t.index ["user_id"], name: "index_cook_laters_on_user_id"
   end
 
   create_table "food_nutrients", force: :cascade do |t|
@@ -115,6 +124,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_28_123204) do
 
   add_foreign_key "comments", "recipes"
   add_foreign_key "comments", "users"
+  add_foreign_key "cook_laters", "recipes"
+  add_foreign_key "cook_laters", "users"
   add_foreign_key "food_nutrients", "foods"
   add_foreign_key "food_nutrients", "nutrients"
   add_foreign_key "recipe_foods", "foods"


### PR DESCRIPTION
## **実装した内容**
- [x] マイグレーションファイル適用
- [x] cook_laterモデルの作成
- [x] userモデル、recipeモデルへアソシエーション設定

## **実装したコード**
### 20240829104227_create_cook_laters.rb 
（cook_latersテーブル作成マイグレーションファイル）
```rb
class CreateCookLaters < ActiveRecord::Migration[7.1]
  def change
    create_table :cook_laters do |t|
      t.references :user, foreign_key: true
      t.references :recipe, foreign_key: true

      t.timestamps
      add_index :cook_laters, [:user_id, :recipe_id], unique: true
        # 同じuser_idとrecipe_idの組み合わせが重複しないようにする
    end
  end
end
```
---

### schema.rb（テーブル中身）
```rb
  create_table "cook_laters", force: :cascade do |t|
    t.bigint "user_id"
    t.bigint "recipe_id"
    t.datetime "created_at", null: false
    t.datetime "updated_at", null: false
    t.index ["recipe_id"], name: "index_cook_laters_on_recipe_id"
    t.index ["user_id"], name: "index_cook_laters_on_user_id"
  end

...(略)...

  add_foreign_key "cook_laters", "recipes"
  add_foreign_key "cook_laters", "users"
```
---
### cook_later.rb （作りたいものリストのモデル、中間テーブル）
```rb
class Cooklater < ApplicationRecord
  belong_to :user
  belong_to :recipe

  validates :user_id, uniqueness: { scope: :recipe_id }
    # 1人のユーザーは1つのレシピに対して、1つのCooklaterしか作成できない
end
```
---

### user.rb（cook_laterモデルとの関連性を記述）
```rb
class User < ApplicationRecord

...(略)...

  has_many :cook_laters, through: :cook_laters, source: :recipe
  # ユーザーはcook_latersを通じてrecipeテーブルへのアクセス権限を持つ
  # user.cook_later_recipesで、ユーザーが「作りたいものリスト」へ追加したレシピを取得できる
```
---
### recipe.rb（cook_laterモデルとの関連性を記述）
```rb
class Recipe < ApplicationRecord

...(略)...

  has_many :cook_laters, dependent: :destroy
```

関連するIssue: #158 Bookmark機能（作りたいものリスト、モデル）