### PR TITLE
今日の献立（コントローラー）

### DIFF
--- a/app/controllers/daily_menus_controller.rb
+++ b/app/controllers/daily_menus_controller.rb
@@ -1,0 +1,26 @@
+class DailyMenusController < ApplicationController
+  before_action :authenticate_user!, only: %i[create destroy]
+
+  def create
+    recipe = Recipe.find(params[:recipe_id])
+    current_user.daily_menu(recipe)
+
+    respond_to do |format|
+      format.turbo_stream
+      redirect_to request.referer
+    end
+  end
+
+  def destroy
+    daily_menu = current_user.daily_menus.find_by(id: params[:id])
+    recipe = daily_menu.recipe
+    current_user.undaily_menu(recipe)
+    # ログインしているユーザーの今日の献立の中から、指定されたidのレコードを取得
+    # 削除対象のレシピを取得
+
+    respond_to do |format|
+      format.turbo_stream
+      redirect_to request.referer
+    end
+  end
+end


### PR DESCRIPTION
## **実装した内容**
- [x] 今日の献立に追加、削除をする処理を定義

## **実装したコード**
### 今日の献立に追加、削除する処理
- daily_menus_controller.rb
```rb
class DailyMenusController < ApplicationController
  before_action :authenticate_user!, only: %i[create destroy]

  def create
    recipe = Recipe.find(params[:recipe_id])
    current_user.daily_menu(recipe)

    respond_to do |format|
      format.turbo_stream
      redirect_to request.referer
    end
  end

  def destroy
    daily_menu = current_user.daily_menus.find_by(id: params[:id])
    recipe = daily_menu.recipe
    current_user.undaily_menu(recipe)
    # ログインしているユーザーの今日の献立の中から、指定されたidのレコードを取得
    # 削除対象のレシピを取得

    respond_to do |format|
      format.turbo_stream
      redirect_to request.referer
    end
  end
end
```
関連するIssue: #169 今日の献立（コントローラー）
