### PR TITLE
本番環境下でのデフォルトURL修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,7 +76,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # メールのデフォルトURL設定（メール内のリンクなどに使用される）
-  config.action_mailer.default_url_options = { host: 'https://baby-gourmet-v1-0.onrender.com/' }
+  config.action_mailer.default_url_options = { host: 'https://baby-gourmet-v1-0.onrender.com' }
 
   # メール送信方法をSMTP（Simple Mail Transfer Protocol）に設定
   config.action_mailer.delivery_method = :smtp


### PR DESCRIPTION
## **実装した内容**
- [x]  本番環境で使用するURL設定を修正しました。

## **実装したコード**
### URL末尾の / を削除しました
- config/environments/production.rb
```rb
  # SMTPサーバーの詳細設定
  config.action_mailer.smtp_settings = {
    address:              'smtp.gmail.com',
    port:                 587,
    domain:               'baby-gourmet-v1-0.onrender.com',
    user_name:            ENV['MAILER_SENDER'],
    password:             ENV['MAILER_PASSWORD'],
    authentication:       'plain',
    enable_starttls_auto: true
  }
```