### PR TITLE
usersルーティングをdeviseルーティングより後ろへ修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,9 +2,6 @@ Rails.application.routes.draw do
 
   root 'tops#index'
 
-  resources :users, only: [:show], as: :my_page
-  get 'users/:id/profile', to: 'users#profile', as: :profile
-
   # 認証に必要なルーティングを自動生成する
   devise_for :users, controllers: {
     registrations: 'users/registrations',
@@ -26,6 +23,9 @@ Rails.application.routes.draw do
     post 'login', to: 'users/sessions#create'
     delete 'logout', to: 'users/sessions#destroy', as: :logout
   end
+
+  resources :users, only: [:show], as: :my_page
+  get 'users/:id/profile', to: 'users#profile', as: :profile
 
   resources :recipes do
     collection do


### PR DESCRIPTION
## **実装した内容**
- [x] usersルーティングをdeviseルーティングより後ろへ修正

## **実装したコード**
### usersルーティングをdeviseルーティングより後ろへ修正しました。
- routes.rb
```rb
Rails.application.routes.draw do

  root 'tops#index'

  # 認証に必要なルーティングを自動生成する
  devise_for :users, controllers: {
    registrations: 'users/registrations',
    sessions:      'users/sessions',
    passwords:     'users/passwords',
  }, skip: %i[registrations sessions]
  # skip: [:registrations, :sessions]で自動生成するルーティングを制限する
  # 制限理由: ユーザー登録、ログイン、ログアウトのルーティングを可読性良くカスタマイズするため

  devise_scope :user do
    # devise_scope: どのルーティングを変更するかを指定する
    get 'sign_up', to: 'users/registrations#new', as: :new_user
    post 'users', to: 'users/registrations#create', as: :users
    get 'users/:id/edit', to: 'users/registrations#edit', as: :edit_user
    patch 'users/:id', to: 'users/registrations#update', as: :user
    delete 'users/:id', to: 'users/registrations#destroy', as: :delete_user

    get 'login', to: 'users/sessions#new', as: :login
    post 'login', to: 'users/sessions#create'
    delete 'logout', to: 'users/sessions#destroy', as: :logout
  end

  resources :users, only: [:show], as: :my_page
  get 'users/:id/profile', to: 'users#profile', as: :profile

...(略)...

```
